### PR TITLE
Specify Dependency of Release on Build Job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - name: Download binary artifact
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Such that a release is created _after_ a binary has been built.