### PR TITLE
Checkout repo before using gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,9 @@ jobs:
       - test
       - build
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download x86_64 binary artifact
         id: download-x86_64
         uses: actions/download-artifact@v4


### PR DESCRIPTION
_Should_ fix the release workflow.