### PR TITLE
Set GH_TOKEN env var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,4 +81,4 @@ jobs:
             '${{ steps.download.outputs.download-path }}/ipupdate-x86_64/ipupdate#ipupdate-${{ github.ref_name }}-x86_64-linux' \
             '${{ steps.download.outputs.download-path }}/ipupdate-aarch64/ipupdate#ipupdate-${{ github.ref_name }}-aarch64-linux'
         env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+          GH_TOKEN: ${{ secrets.github_token }}


### PR DESCRIPTION
To enable release creation via GH CLI.